### PR TITLE
always generate new puppeteer page

### DIFF
--- a/src/pages/api/_lib/chromium.ts
+++ b/src/pages/api/_lib/chromium.ts
@@ -3,6 +3,7 @@ import { OG_HEIGHT, OG_WIDTH } from "../../../constants";
 import { FileType } from "../../../types";
 import { getOptions } from "./options";
 
+// test
 async function getPage(isDev: boolean) {
   const options = await getOptions(isDev);
   const browser = await core.launch(options);

--- a/src/pages/api/_lib/chromium.ts
+++ b/src/pages/api/_lib/chromium.ts
@@ -2,16 +2,11 @@ import core from "puppeteer-core";
 import { OG_HEIGHT, OG_WIDTH } from "../../../constants";
 import { FileType } from "../../../types";
 import { getOptions } from "./options";
-let _page: core.Page | null;
 
 async function getPage(isDev: boolean) {
-  if (_page) {
-    return _page;
-  }
   const options = await getOptions(isDev);
   const browser = await core.launch(options);
-  _page = await browser.newPage();
-  return _page;
+  return await browser.newPage();
 }
 
 export async function getScreenshot(


### PR DESCRIPTION
There was a race condition where incorrect image were returned. This was because the puppteer page object was reused. Creating a new page everytime should fix the race.
